### PR TITLE
Revert named Kernels as it will never work when SF also creates Kernels.

### DIFF
--- a/src/Zicht/SymfonyUtil/HttpKernel/Kernel.php
+++ b/src/Zicht/SymfonyUtil/HttpKernel/Kernel.php
@@ -51,16 +51,16 @@ abstract class Kernel extends SymfonyKernel
 
     /**
      * Overrides the default constructor to use APPLICATION_ENV and default debugging.
+     * Do not change the arguments, as Symfony will also create Kernels (e.g. from CacheClearCommand), but always with 2 arguments.
      *
-     * @param string $appName
      * @param string $environment
      * @param bool $debug
      */
-    public function __construct($name = null, $environment = null, $debug = null)
+    public function __construct($environment = null, $debug = null)
     {
         umask(0);
 
-        $this->name = $name ?: getenv('APPLICATION_NAME') ?: 'app';
+        $this->name = getenv('APPLICATION_NAME') ?: 'app';
         $environment = $environment ?: getenv('APPLICATION_ENV');
         $debug = (
             null === $debug


### PR DESCRIPTION
This PR should probably be merged in a new 2.0 release-branch as it breaks BC.