### PR TITLE
Change order of Kernel-args

### DIFF
--- a/doc/multiple-kernels.md
+++ b/doc/multiple-kernels.md
@@ -42,9 +42,9 @@ require_once __DIR__.'/../app/bootstrap.php.cache';
 require_once __DIR__.'/../app/AppKernel.php';
 
 if (preg_match('!^/admin/!', $_SERVER['REQUEST_URI'])) {
-    (new AppKernel('admin'))->web();
+    (new AppKernel(null, null, 'admin'))->web();
 } else {
-    (new AppKernel('site'))->web();
+    (new AppKernel(null, null, 'site'))->web();
 }
 ```
 

--- a/src/Zicht/SymfonyUtil/HttpKernel/Kernel.php
+++ b/src/Zicht/SymfonyUtil/HttpKernel/Kernel.php
@@ -52,11 +52,11 @@ abstract class Kernel extends SymfonyKernel
     /**
      * Overrides the default constructor to use APPLICATION_ENV and default debugging.
      *
-     * @param string $appName
      * @param string $environment
      * @param bool $debug
+     * @param string $name
      */
-    public function __construct($name = null, $environment = null, $debug = null)
+    public function __construct($environment = null, $debug = null, $name = null)
     {
         umask(0);
 


### PR DESCRIPTION
Change name-param order as Symfony also creates Kernels and expects param 1 and 2 to be env / debug