### PR TITLE
Disable rendering of HTML in 404 of static media

### DIFF
--- a/src/Zicht/SymfonyUtil/HttpKernel/StaticMediaNotFoundHandler.php
+++ b/src/Zicht/SymfonyUtil/HttpKernel/StaticMediaNotFoundHandler.php
@@ -63,6 +63,6 @@ class StaticMediaNotFoundHandler implements HandlerInterface
      */
     protected function createDefaultNotFoundResponse($path)
     {
-        return new Response('File not found: ' . $path, 404);
+        return new Response(sprintf('File not found: %s', htmlspecialchars($path, ENT_QUOTES)), 404);
     }
 }


### PR DESCRIPTION
Fix to prevent XSS requests: the path variable was rendered directly in the response, without escaping.

Jira issue: https://zichtonline.atlassian.net/browse/ZICHTDEV-1022